### PR TITLE
Configure gitignore to ignore built assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+dist/


### PR DESCRIPTION
Ive been enjoying this cursor theme quite a bit. I noticed that when running the `make build`, the assets are showing up as pending changes to the repo.

By adding in this gitignore we can help make sure they dont accidentally get checked in.